### PR TITLE
upgrade: go & azurerm tf provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ DRY is a great concept, and you should be aware that it will come true in the fu
 Prerequisites & tested
 
 - [Terraform](https://www.terraform.io/docs/index.html): 1.2.6
-  - hashicorp/azurerm: 3.16.0
+  - hashicorp/azurerm: 3.17.0
   - hashicorp/kubernetes: 2.12
   - State store: Local
 - [TFLint](https://github.com/terraform-linters/tflint): 0.38.1

--- a/terraform/blue/aks/main.tf
+++ b/terraform/blue/aks/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.16.0"
+      version = "~> 3.17.0"
     }
   }
 }

--- a/terraform/blue/main.tf
+++ b/terraform/blue/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.16.0"
+      version = "~> 3.17.0"
     }
 
     kubernetes = {

--- a/terraform/green/aks/main.tf
+++ b/terraform/green/aks/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.16.0"
+      version = "~> 3.17.0"
     }
   }
 }

--- a/terraform/green/main.tf
+++ b/terraform/green/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.16.0"
+      version = "~> 3.17.0"
     }
 
     kubernetes = {

--- a/terraform/shared/main.tf
+++ b/terraform/shared/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.16.0"
+      version = "~> 3.17.0"
     }
 
     random = {

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/ToruMakabe/aks-playground/test/e2e
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.1


### PR DESCRIPTION
- upgrade: go 1.19 (improve handling timeout & replace deprecated package)
- bump: azurerm tf provider
